### PR TITLE
replace http://repo2.maven.org with https://repo.maven.apache.org/

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The plugin can scan packages at the following repositories:
 13. Artifactory Proxy Repos - supported repository formats are maven2 and npm e.g. https://repo.spring.io/webapp/#/artifacts/browse/tree/General/npmjs-cache/parseurl/-/parseurl-1.0.1.tgz
 14. Artifactory Repo lists - e.g. https://repo.spring.io/list/jcenter-cache/org/cloudfoundry/cf-maven-plugin/1.1.3/
 15. Maven Repo1 - https://repo1.maven.org/maven2/
-16. Maven Repo2 - http://repo.maven.org/maven2/
+16. Maven Repo - https://repo.maven.apache.org/maven2/
 
 ## Documentation
 
@@ -103,8 +103,8 @@ Pattern -`https://mvnrepository.com/artifact/<group>/<artifact>/<version>`
 Pattern - `https://repo1.maven.org/maven2/<group>/<artifact>/<version>/`
 <br/> e.g. <https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/>
 
-Pattern - `http://repo2.maven.org/maven2/<group>/<artifact>/<version>/`
-<br/> e.g. <http://repo2.maven.org/maven2/commons-collections/commons-collections/3.2.1/>
+Pattern - `https://repo.maven.apache.org/maven2/<group>/<artifact>/<version>/`
+<br/> e.g. <https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/>
 
 ### JS/Node - npm
 

--- a/docs/background.js.html
+++ b/docs/background.js.html
@@ -547,10 +547,10 @@ browser.runtime.onInstalled.addListener(function() {
             }
           }),
           new browser.declarativeContent.PageStateMatcher({
-            //http://repo2.maven.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
+            //https://repo.maven.apache.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
             pageUrl: {
-              hostEquals: "repo2.maven.org",
-              schemes: ["http"],
+              hostEquals: "repo.maven.apache.org",
+              schemes: ["https"],
               pathContains: "maven2"
             }
           }),

--- a/src/Scripts/background.js
+++ b/src/Scripts/background.js
@@ -581,10 +581,10 @@ browser.runtime.onInstalled.addListener(function() {
             }
           }),
           new browser.declarativeContent.PageStateMatcher({
-            //http://repo2.maven.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
+            //https://repo.maven.apache.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
             pageUrl: {
-              hostEquals: "repo2.maven.org",
-              schemes: ["http"],
+              hostEquals: "repo.maven.apache.org",
+              schemes: ["https"],
               pathContains: "maven2"
             }
           }),

--- a/src/Scripts/utils.js
+++ b/src/Scripts/utils.js
@@ -222,7 +222,7 @@ const checkPageIsHandled = url => {
     url.search("https://search.maven.org/artifact/") >= 0 ||
     url.search("https://mvnrepository.com/artifact/") >= 0 ||
     url.search("https://repo1.maven.org/maven2/") >= 0 ||
-    url.search("http://repo2.maven.org/maven2/") >= 0 ||
+    url.search("https://repo.maven.apache.org/maven2/") >= 0 ||
     url.search("https://www.npmjs.com/package/") >= 0 ||
     url.search("https://www.nuget.org/packages/") >= 0 ||
     url.search("https://pypi.org/project/") >= 0 ||
@@ -264,9 +264,9 @@ const ParsePageURL = url => {
     //https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/
     format = formats.maven;
     artifact = parseMavenURL(url);
-  } else if (url.search("http://repo2.maven.org/maven2/") >= 0) {
+  } else if (url.search("https://repo.maven.apache.org/maven2/") >= 0) {
     //can not be parsed need to inject script and parse html
-    //http://repo2.maven.org/maven2/commons-collections/commons-collections/3.2.1/
+    //https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/
     format = formats.maven;
     artifact = parseMavenURL(url);
   } else if (url.search("www.npmjs.com/package/") >= 0) {
@@ -730,7 +730,7 @@ const parseMavenURL = url => {
   //maven repo https://mvnrepository.com/artifact/commons-collections/commons-collections/3.2.1
   //SEARCH      https://search.maven.org/artifact/commons-collections/commons-collections/3.2.1/jar
   //https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/
-  //http://repo2.maven.org/maven2/commons-collections/commons-collections/3.2.1/
+  //https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/
   //https://repo1.maven.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
   //CURRENTLY both have the same format in the URL version, except maven central also has the packaging type
   let format = formats.maven;

--- a/src/Scripts/utils_original.js
+++ b/src/Scripts/utils_original.js
@@ -220,7 +220,7 @@ const checkPageIsHandled = url => {
     url.search("https://search.maven.org/artifact/") >= 0 ||
     url.search("https://mvnrepository.com/artifact/") >= 0 ||
     url.search("https://repo1.maven.org/maven2/") >= 0 ||
-    url.search("http://repo2.maven.org/maven2/") >= 0 ||
+    url.search("https://repo.maven.apache.org/maven2/") >= 0 ||
     url.search("https://www.npmjs.com/package/") >= 0 ||
     url.search("https://www.nuget.org/packages/") >= 0 ||
     url.search("https://pypi.org/project/") >= 0 ||
@@ -261,9 +261,9 @@ const ParsePageURL = url => {
     //https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/
     format = formats.maven;
     artifact = parseMavenURL(url);
-  } else if (url.search("http://repo2.maven.org/maven2/") >= 0) {
+  } else if (url.search("https://repo.maven.apache.org/maven2/") >= 0) {
     //can not be parsed need to inject script and parse html
-    //http://repo2.maven.org/maven2/commons-collections/commons-collections/3.2.1/
+    //https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/
     format = formats.maven;
     artifact = parseMavenURL(url);
   } else if (url.search("www.npmjs.com/package/") >= 0) {
@@ -696,7 +696,7 @@ const parseMavenURL = url => {
   //maven repo https://mvnrepository.com/artifact/commons-collections/commons-collections/3.2.1
   //SEARCH      https://search.maven.org/artifact/commons-collections/commons-collections/3.2.1/jar
   //https://repo1.maven.org/maven2/commons-collections/commons-collections/3.2.1/
-  //http://repo2.maven.org/maven2/commons-collections/commons-collections/3.2.1/
+  //https://repo.maven.apache.org/maven2/commons-collections/commons-collections/3.2.1/
   //https://repo1.maven.org/maven2/com/github/jedis-lock/jedis-lock/1.0.0/
   //CURRENTLY both have the same format in the URL version, except maven central also has the packaging type
   let format = formats.maven;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
     "https://search.maven.org/",
     "https://mvnrepository.com/",
     "https://repo1.maven.org/",
-    "http://repo2.maven.org/",
+    "https://repo.maven.apache.org/",
     "https://www.npmjs.com/",
     "https://www.nuget.org/",
     "https://rubygems.org/",

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -16,7 +16,7 @@
     "https://search.maven.org/",
     "https://mvnrepository.com/",
     "https://repo1.maven.org/",
-    "http://repo2.maven.org/",
+    "https://repo.maven.apache.org/",
     "https://www.npmjs.com/",
     "https://www.nuget.org/",
     "https://rubygems.org/",


### PR DESCRIPTION
http://repo2.maven.org does not exist any more
but https://repo.maven.apache.org/ is used by Maven itself