### PR TITLE
fix CI build failure by using latest semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsdoc": "^3.6.4",
     "puppeteer": "^3.0.1",
     "selenium-webdriver": "^4.0.0-alpha.7",
-    "semantic-release": "^17.0.7",
+    "semantic-release": "^17.2.1",
     "semantic-release-chrome": "^1.1.3"
   },
   "dependencies": {}


### PR DESCRIPTION
A recent [branch build](https://app.circleci.com/pipelines/github/sonatype-nexus-community/nexus-iq-chrome-extension/338/workflows/b30385a4-afe3-4063-8acc-899a72bd3c68/jobs/316) (for PR #102)  and my attempts to run a local CircleCI build failed with a message like this:

```
npm ERR! notarget No matching version found for yaml@1.9.3.
```

Updating to the latest version of `semantic-release` appears to solve that problem.

@hboutemy @ctownshend 