### PR TITLE
Iterate over multiple licenses

### DIFF
--- a/src/Scripts/popup.js
+++ b/src/Scripts/popup.js
@@ -540,7 +540,7 @@ const renderLicenseData = (message) => {
         target: '_blank',
       }).appendTo("#declaredLicensesSpan");
 
-      if (licenseData.declaredLicenses.length - i != 1) {
+      if (i < licenseData.declaredLicenses.length - 1) {
         $("#declaredLicensesSpan").append(", ");
       }
       console.log("link", link, licenseData.declaredLicenses[i].licenseName);
@@ -549,7 +549,7 @@ const renderLicenseData = (message) => {
         licenseData.declaredLicenses[i].licenseName
       );
 
-      if (licenseData.declaredLicenses.length - i != 1) {
+      if (i < licenseData.declaredLicenses.length - 1) {
         $("#declaredLicensesNamesSpan").append(", ");
       }
     }
@@ -560,7 +560,7 @@ const renderLicenseData = (message) => {
         licenseData.observedLicenses[i].licenseId
       );
 
-      if (licenseData.observedLicenses.length - i != 1) {
+      if (i < licenseData.observedLicenses.length - 1) {
         $("#observedLicensesSpan").append(", ");
       }
   
@@ -568,7 +568,7 @@ const renderLicenseData = (message) => {
         licenseData.observedLicenses[i].licenseName
       );
 
-      if (licenseData.observedLicenses.length - i != 1) {
+      if (i < licenseData.observedLicenses.length - 1) {
         $("#observedLicensesNameSpan").append(", ");
       }
     }

--- a/src/Scripts/popup.js
+++ b/src/Scripts/popup.js
@@ -524,34 +524,53 @@ const renderSecuritySummaryOSSIndex = (message) => {
 const renderLicenseData = (message) => {
   var thisComponent = message.message.response.componentDetails["0"];
   let licenseData = thisComponent.licenseData;
+  
+  // Temporary fix, HTML, etc.. should likely be revamped
   if (licenseData.declaredLicenses.length > 0) {
-    if (licenseData.declaredLicenses["0"].licenseId) {
-      //$("#declaredlicenses_licenseId").html(licenseData.declaredLicenses["0"].licenseId);
-      //<a href="https://en.wikipedia.org/wiki/{{{licenseId}}}_License" target="_blank">https://en.wikipedia.org/wiki/{{{licenseId}}}_License</a>
-      //https://spdx.org/licenses/0BSD.html
+    for (let i = 0; i < licenseData.declaredLicenses.length; i++) {
       let link =
         "https://en.wikipedia.org/wiki/" +
-        licenseData.declaredLicenses["0"].licenseId +
+        licenseData.declaredLicenses[i].licenseId +
         "_License";
-      console.log("link", link, licenseData.declaredLicenses["0"].licenseName);
-      $("#declaredlicenses_licenseLink").attr("href", link);
-      $("#declaredlicenses_licenseLink").html(
-        licenseData.declaredLicenses["0"].licenseId
+
+      $('<a>', {
+        text: licenseData.declaredLicenses[i].licenseId,
+        title: 'License ID',
+        href: link,
+      }).appendTo("#declaredLicensesSpan");
+
+      if (licenseData.declaredLicenses.length - i != 1) {
+        $("#declaredLicensesSpan").append(", ");
+      }
+      console.log("link", link, licenseData.declaredLicenses[i].licenseName);
+
+      $("#declaredLicensesNamesSpan").append(
+        licenseData.declaredLicenses[i].licenseName
       );
+
+      if (licenseData.declaredLicenses.length - i != 1) {
+        $("#declaredLicensesNamesSpan").append(", ");
+      }
     }
-    //$("#declaredlicenses_licenseLink").html(licenseData.declaredLicenses["0"].licenseId);
-    $("#declaredlicenses_licenseName").html(
-      licenseData.declaredLicenses["0"].licenseName
-    );
   }
-  if (thisComponent.licenseData.observedLicenses.length > 0) {
-    $("#observedLicenses_licenseId").html(
-      thisComponent.licenseData.observedLicenses["0"].licenseId
-    );
-    //document.getElementById("observedLicenses_licenseLink").innerHTML = componentInfoData.componentDetails["0"].licenseData.observedLicenses["0"].licenseName;
-    $("#observedLicenses_licenseName").html(
-      thisComponent.licenseData.observedLicenses["0"].licenseName
-    );
+  if (licenseData.observedLicenses.length > 0) {
+    for (let i = 0; i < licenseData.observedLicenses.length; i++) {
+      $("#observedLicensesSpan").append(
+        licenseData.observedLicenses[i].licenseId
+      );
+
+      if (licenseData.observedLicenses.length - i != 1) {
+        $("#observedLicensesSpan").append(", ");
+      }
+  
+      $("#observedLicensesNameSpan").append(
+        licenseData.observedLicenses[i].licenseName
+      );
+
+      if (licenseData.observedLicenses.length - i != 1) {
+        $("#observedLicensesNameSpan").append(", ");
+      }
+    }
   }
 };
 

--- a/src/Scripts/popup.js
+++ b/src/Scripts/popup.js
@@ -524,7 +524,7 @@ const renderSecuritySummaryOSSIndex = (message) => {
 const renderLicenseData = (message) => {
   var thisComponent = message.message.response.componentDetails["0"];
   let licenseData = thisComponent.licenseData;
-  
+
   // Temporary fix, HTML, etc.. should likely be revamped
   if (licenseData.declaredLicenses.length > 0) {
     for (let i = 0; i < licenseData.declaredLicenses.length; i++) {
@@ -537,6 +537,7 @@ const renderLicenseData = (message) => {
         text: licenseData.declaredLicenses[i].licenseId,
         title: 'License ID',
         href: link,
+        target: '_blank',
       }).appendTo("#declaredLicensesSpan");
 
       if (licenseData.declaredLicenses.length - i != 1) {

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -124,16 +124,12 @@
           <div id="declaredlicenses">
             <tr>
               <td>
-                License Id:
-                <a
-                  id="declaredlicenses_licenseLink"
-                  href="test.html"
-                  target="_blank"
-                  >LicenseLink</a
-                >
+                <b>License ID(s): </b>
+                <span id ="declaredLicensesSpan" ></span>
               </td>
               <td>
-                License Name: <span id="declaredlicenses_licenseName"></span>
+                License Name(s): 
+                <span id = "declaredLicensesNamesSpan"></span>
               </td>
             </tr>
           </div>
@@ -145,10 +141,11 @@
           </tr>
           <div id="observedlicenses">
             <tr>
-              <td>License Id: <span id="observedLicenses_licenseId"></span></td>
               <td>
-                <div id="observedLicenses_licenseLink"></div>
-                License Name: <span id="observedLicenses_licenseName"></span>
+                License Id: <span id="observedLicensesSpan"></span>
+              </td>
+              <td>
+                License Name: <span id="observedLicensesNameSpan"></span>
               </td>
             </tr>
           </div>


### PR DESCRIPTION
This is a fix for a customer submitted issue. For the time being, iterate over the licenses declared and observed, and output them as a comma separated list. 

UI looks like this:

<img width="548" alt="Screen Shot 2020-12-24 at 7 59 22 AM" src="https://user-images.githubusercontent.com/5544326/103100177-f070ec80-45bd-11eb-9e4d-a1412afa0303.png">

Likely long term the tables should be broken apart, that way it would be easier to just add new tr, td, as you iterate.