### PR TITLE
Fix: Get csrfProtection enabled working

### DIFF
--- a/src/NexusChromeExtensionContainer.tsx
+++ b/src/NexusChromeExtensionContainer.tsx
@@ -20,7 +20,7 @@ import {
   OSSIndexRequestService,
   RequestService
 } from '@sonatype/js-sona-types';
-import localforage, {setItem} from 'localforage';
+import localforage from 'localforage';
 import {PackageURL} from 'packageurl-js';
 import React from 'react';
 import AlpDrawer from './components/AlpDrawer/AlpDrawer';
@@ -32,8 +32,6 @@ import {findRepoType} from './utils/UrlParsing';
 
 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 const _browser = chrome ? chrome : browser;
-const X_CSRF_TOKEN = 'X-CSRF-TOKEN';
-const CSRF_COOKIE_NAME = 'CLM-CSRF-TOKEN';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AppProps = any;
@@ -74,15 +72,6 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
           resolve(defaultValue);
         }
       });
-    });
-  };
-
-  setStorageItem = (value: string, key: string) => {
-    console.info('setItem: ', key, value);
-    chrome.storage.local.set({[key]: value}, () => {
-      if (chrome.runtime.lastError) {
-        console.error(chrome.runtime.lastError.message);
-      }
     });
   };
 
@@ -172,34 +161,16 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
     });
   };
 
-  getCSRFTokenFromStorage = async (): Promise<string> => {
-    console.info("getCSRFTokenFromStorage")
-    return await this.getStorageValue(CSRF_COOKIE_NAME, undefined);
-  };
-
-  // getCSRFTokenFromCookie = (): Promise<string> => {
-  //   return new Promise((resolve, reject) => {
-  //     chrome.cookies.getAll({name: 'CLM-CSRF-TOKEN'}, (cookies) => {
-  //       if (cookies.length > 0) {
-  //         resolve(cookies[0].value);
-  //       } else if (this.getCSRFTokenFromStorage.length > 0) {
-  //         console.info("call getCSRFTokenFromStorage from getCSRFTokenFromCookie")
-  //         resolve(this.getCSRFTokenFromStorage());
-  //       }
-  //       else {
-  //         reject('No valid cookie found');
-  //       }
-  //     });
-  //   });
-  // };
-  getCSRFTokenFromCookie = async (): Promise<string> => {
+  setCSRFTokenCookie = async (): Promise<string> => {
     const host = await this.getStorageValue('iqServerURL', undefined);
+    console.info("getCSRFTokenFromCookie with:", host)
     return new Promise((resolve) => {
       chrome.cookies.set({
         url: host,
         name: 'CLM-CSRF-TOKEN',
-        value: 'api'}, () => {
-          resolve('api');
+        value: 'api'}, (success) => {
+        console.log('Cookie set:', success);
+        resolve('api');
       });
     });
   };
@@ -344,31 +315,32 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
           // this.state.logger?.logMessage('Logged in to Nexus IQ Server', LogLevel.TRACE, loggedIn);
           // console.info('Logged in to Nexus IQ Server', LogLevel.INFO, loggedIn);
 
-          this.getCSRFTokenFromCookie()
+          this.setCSRFTokenCookie()
             .then(async (token) => {
               (this._requestService as IqRequestService).setXCSRFToken(token);
+
               const status = await (
                 this._requestService as IqRequestService
               ).getComponentEvaluatedAgainstPolicy([purl]);
 
-              (this._requestService as IqRequestService).asyncPollForResults(
-                `/${status.resultsUrl}`,
-                (e) => {
-                  throw new Error(e);
-                },
-                (results) => {
-                  this.state.logger?.logMessage(
-                    'Got results from Nexus IQ Server for Component Policy Eval',
-                    LogLevel.TRACE,
-                    {
-                      results: results
-                    }
-                  );
-                  console.info('Got results from Nexus IQ Server for Component Policy Eval');
-                  this.setState({policyDetails: results});
-                  this.doRequestForComponentDetails(purl);
-                  this.getAllVersions(purlString);
-                }
+              await (this._requestService as IqRequestService).asyncPollForResults(
+                  `/${status.resultsUrl}`,
+                  (e) => {
+                    throw new Error(e);
+                  },
+                  (results) => {
+                    this.state.logger?.logMessage(
+                        'Got results from Nexus IQ Server for Component Policy Eval',
+                        LogLevel.TRACE,
+                        {
+                          results: results
+                        }
+                    );
+                    console.info('Got results from Nexus IQ Server for Component Policy Eval');
+                    this.setState({policyDetails: results});
+                    this.doRequestForComponentDetails(purl);
+                    this.getAllVersions(purlString);
+                  }
               );
             })
             .catch((err: Error) => {

--- a/src/NexusChromeExtensionContainer.tsx
+++ b/src/NexusChromeExtensionContainer.tsx
@@ -20,7 +20,7 @@ import {
   OSSIndexRequestService,
   RequestService
 } from '@sonatype/js-sona-types';
-import localforage from 'localforage';
+import localforage, {setItem} from 'localforage';
 import {PackageURL} from 'packageurl-js';
 import React from 'react';
 import AlpDrawer from './components/AlpDrawer/AlpDrawer';
@@ -32,6 +32,8 @@ import {findRepoType} from './utils/UrlParsing';
 
 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 const _browser = chrome ? chrome : browser;
+const X_CSRF_TOKEN = 'X-CSRF-TOKEN';
+const CSRF_COOKIE_NAME = 'CLM-CSRF-TOKEN';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AppProps = any;
@@ -72,6 +74,15 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
           resolve(defaultValue);
         }
       });
+    });
+  };
+
+  setStorageItem = (value: string, key: string) => {
+    console.info('setItem: ', key, value);
+    chrome.storage.local.set({[key]: value}, () => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError.message);
+      }
     });
   };
 
@@ -161,14 +172,34 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
     });
   };
 
-  getCSRFTokenFromCookie = (): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      chrome.cookies.getAll({name: 'CLM-CSRF-TOKEN'}, (cookies) => {
-        if (cookies.length > 0) {
-          resolve(cookies[0].value);
-        } else {
-          reject('No valid cookie found');
-        }
+  getCSRFTokenFromStorage = async (): Promise<string> => {
+    console.info("getCSRFTokenFromStorage")
+    return await this.getStorageValue(CSRF_COOKIE_NAME, undefined);
+  };
+
+  // getCSRFTokenFromCookie = (): Promise<string> => {
+  //   return new Promise((resolve, reject) => {
+  //     chrome.cookies.getAll({name: 'CLM-CSRF-TOKEN'}, (cookies) => {
+  //       if (cookies.length > 0) {
+  //         resolve(cookies[0].value);
+  //       } else if (this.getCSRFTokenFromStorage.length > 0) {
+  //         console.info("call getCSRFTokenFromStorage from getCSRFTokenFromCookie")
+  //         resolve(this.getCSRFTokenFromStorage());
+  //       }
+  //       else {
+  //         reject('No valid cookie found');
+  //       }
+  //     });
+  //   });
+  // };
+  getCSRFTokenFromCookie = async (): Promise<string> => {
+    const host = await this.getStorageValue('iqServerURL', undefined);
+    return new Promise((resolve) => {
+      chrome.cookies.set({
+        url: host,
+        name: 'CLM-CSRF-TOKEN',
+        value: 'api'}, () => {
+          resolve('api');
       });
     });
   };
@@ -307,11 +338,11 @@ class NexusChromeExtensionContainer extends React.Component<AppProps, NexusConte
         console.info('Parsed purl into object', LogLevel.TRACE, purl);
 
         if (this._requestService instanceof IqRequestService) {
-          this.state.logger?.logMessage('Attempting to login to Nexus IQ Server', LogLevel.INFO);
-          console.info('Attempting to login to Nexus IQ Server', LogLevel.INFO);
-          const loggedIn = await this._requestService.loginViaRest();
-          this.state.logger?.logMessage('Logged in to Nexus IQ Server', LogLevel.TRACE, loggedIn);
-          console.info('Logged in to Nexus IQ Server', LogLevel.INFO, loggedIn);
+          // this.state.logger?.logMessage('Attempting to login to Nexus IQ Server', LogLevel.INFO);
+          // console.info('Attempting to login to Nexus IQ Server', LogLevel.INFO);
+          // const loggedIn = await this._requestService.loginViaRest();
+          // this.state.logger?.logMessage('Logged in to Nexus IQ Server', LogLevel.TRACE, loggedIn);
+          // console.info('Logged in to Nexus IQ Server', LogLevel.INFO, loggedIn);
 
           this.getCSRFTokenFromCookie()
             .then(async (token) => {

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -149,16 +149,16 @@ const setCSRFTokenCookie = async (host: string): Promise<string> => {
   });
 };
 
-const _doRequestToIQServer = (
-  requestService: IqRequestService,
-  purl: string
-): Promise<ComponentDetails> => {
+const _doRequestToIQServer = (requestService: IqRequestService, purl: string): Promise<ComponentDetails> => {
   return new Promise((resolve) => {
+    logger.logMessage('Calling setCSRFTokenCookie with: ', LogLevel.ERROR, requestService.options.host as string);
+
     setCSRFTokenCookie(requestService.options.host as string)
         .then(async (token) => {
           requestService.setXCSRFToken('api');
-        });
+
     const purlObj = PackageURL.fromString(purl);
+
     requestService
       .getComponentDetails([purlObj])
       .then((details) => {
@@ -169,7 +169,7 @@ const _doRequestToIQServer = (
         throw new Error(err);
       });
     });
-  // });
+  });
 };
 
 const handleOSSIndexWrapper = (purl: string, settings: Settings) => {

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -49,6 +49,7 @@ interface Settings {
 }
 
 const getSettings = async (): Promise<Settings> => {
+  console.log("getSettings in extension_service_worker");
   const promise = new Promise<Settings>((resolve) => {
     _browser.storage.local.get(
       [SCAN_TYPE, IQ_SERVER_URL, IQ_SERVER_USER, IQ_SERVER_TOKEN, IQ_SERVER_APPLICATION, LOG_LEVEL],
@@ -111,8 +112,7 @@ const handleURLIQServer = (purl: string, settings: Settings): Promise<ComponentD
       version: manifestData.version
     });
 
-    requestService
-      .loginViaRest()
+      requestService.loginViaRest()
       .then((loggedIn) => {
         if (loggedIn) {
           logger.logMessage('Logged in to Sonatype IQ Server via service worker', LogLevel.INFO);
@@ -122,8 +122,11 @@ const handleURLIQServer = (purl: string, settings: Settings): Promise<ComponentD
             })
             .catch((err) => {
               logger.logMessage('Unable to login to Sonatype IQ server via service worker', LogLevel.ERROR, err.message);
+              console.error('Unable to login to Sonatype IQ server via service worker', err.message);
               throw new Error(err);
             });
+        } else {
+          console.error('Unable to login to Sonatype IQ server via service worker: ', settings);
         }
       })
       .catch((err) => {
@@ -133,29 +136,40 @@ const handleURLIQServer = (purl: string, settings: Settings): Promise<ComponentD
   });
 };
 
+const setCSRFTokenCookie = async (host: string): Promise<string> => {
+  console.info('setting csrf token cookie: ', host);
+  return new Promise((resolve) => {
+    chrome.cookies.set({
+      url: host,
+      name: 'CLM-CSRF-TOKEN',
+      value: 'api'}, (success) => {
+      console.log('Cookie set:', success);
+      resolve('api');
+    });
+  });
+};
+
 const _doRequestToIQServer = (
   requestService: IqRequestService,
   purl: string
 ): Promise<ComponentDetails> => {
   return new Promise((resolve) => {
-    chrome.cookies.getAll({name: 'CLM-CSRF-TOKEN'}, (cookies) => {
-      if (cookies.length > 0) {
-        requestService.setXCSRFToken(cookies[0].value);
-      } else {
-        console.info("No CLM-CSRF=TOKEN found.");
-      }
-      const purlObj = PackageURL.fromString(purl);
-      requestService
-        .getComponentDetails([purlObj])
-        .then((details) => {
-          resolve(details);
-        })
-        .catch((err) => {
-          logger.logMessage('Error: Unable to complete request to IQ server', LogLevel.ERROR, err.message);
-          throw new Error(err);
+    setCSRFTokenCookie(requestService.options.host as string)
+        .then(async (token) => {
+          requestService.setXCSRFToken('api');
         });
+    const purlObj = PackageURL.fromString(purl);
+    requestService
+      .getComponentDetails([purlObj])
+      .then((details) => {
+        resolve(details);
+      })
+      .catch((err) => {
+        logger.logMessage('Error: Unable to complete request to IQ server', LogLevel.ERROR, err.message);
+        throw new Error(err);
+      });
     });
-  });
+  // });
 };
 
 const handleOSSIndexWrapper = (purl: string, settings: Settings) => {
@@ -289,11 +303,14 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (request && request.type) {
     if (request.type === 'getArtifactDetailsFromPurl') {
-      logger.logMessage('Getting settings', LogLevel.INFO);
-      console.info('Getting settings');
+      logger.logMessage('Getting settings in getArtifactDetailsFromPurl', LogLevel.INFO);
+      console.info('Getting settings in getArtifactDetailsFromPurl');
       getSettings()
         .then((settings: Settings) => {
           // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+          if (!settings.host || !settings.application || !settings.scanType || !settings.user || !settings.token ) {
+            console.error('Unable to get settings need to make IQ connection: ', settings);
+          }
           if (settings.logLevel) {
             logger.setLevel(settings.logLevel as unknown as LogLevel);
           }
@@ -307,10 +324,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             }
           } catch (err) {
             logger.logMessage('Error encountered', LogLevel.ERROR, err.message);
+            console.error('Error encountered in getArtifactDetailsFromPurl', err.message);
+
           }
         })
         .catch((err) => {
           logger.logMessage('Error encountered', LogLevel.ERROR, err.message);
+          console.error('Error encountered in getArtifactDetailsFromPurl', err.message);
         });
     }
     if (request.type === 'togglePage') {
@@ -321,7 +341,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === 'install') {
-    chrome.tabs.create({url: 'options.html?install'});
+    chrome.tabs.create({url: 'options.html?install'})
   } else if (details.reason === 'update') {
     /* empty */
   } else if (details.reason === 'chrome_update') {


### PR DESCRIPTION
Get component details requires handling of the csrfProtection from IQ.  This protection is enabled by default.  Both the service working and the container index page both use getComponentDetails API.  Because this api call is a post, it requires the special handling.